### PR TITLE
feat: Add standard project files and GitHub configurations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "single"],
+    "semi": ["error", "always"]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x] # Specify Node.js versions to test against
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm' # Or 'yarn' if the project uses Yarn
+
+    - name: Install dependencies
+      run: npm install # Or yarn install
+
+    # Add linting step if a linter is set up
+    # - name: Lint
+    #   run: npm run lint # Or your specific lint command
+
+    # Add testing step if tests are set up
+    # - name: Test
+    #   run: npm test # Or your specific test command

--- a/CITATION.md
+++ b/CITATION.md
@@ -1,0 +1,21 @@
+# How to Cite This Project
+
+If you use this project in your research or work, please cite it as follows:
+
+[Your Name/Organization]. ([Year]). *[Project Name]*. Retrieved from [Project URL]
+
+## BibTeX Entry
+
+```bibtex
+@misc{YourProject,
+  author = {[Your Name/Organization]},
+  title = {[Project Name]},
+  year = {[Year]},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{[Project URL]}}
+}
+```
+
+Please replace the bracketed placeholders with the appropriate information for this project.
+If this project has a DOI or is published in a journal, please use that information instead.

--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,0 +1,15 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence,
+# @global-owner1 will be requested for review when someone opens a pull request.
+# *       @global-owner1 @global-owner2
+
+# Order is important; the last matching pattern takes the most precedence.
+# So if a pull request only modifies DOCS.md, only @docs-owner will be requested for review.
+# /docs/* @docs-owner
+
+# You can also use email addresses if you prefer. They'll be resolved to
+# GitHub users just like normal.
+# *.txt    docs@example.com

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+We welcome contributions to this project! Please follow these guidelines to ensure a smooth process.
+
+## Getting Started
+
+*   Ensure you have [Link to prerequisite, e.g., Node.js] installed.
+*   Fork the repository and clone it locally.
+*   Create a new branch for your feature or bug fix: `git checkout -b my-feature-branch`
+
+## Making Changes
+
+*   Make your changes, adhering to the coding style (see `.editorconfig` and any linter configurations).
+*   Add tests for any new functionality or bug fixes.
+*   Ensure all tests pass: `[Your test command, e.g., npm test]`
+*   Lint your code: `[Your lint command, e.g., npm run lint]`
+
+## Submitting Changes
+
+*   Commit your changes with a clear and descriptive commit message.
+*   Push your branch to your fork: `git push origin my-feature-branch`
+*   Open a pull request to the `main` branch of this repository.
+*   Provide a clear title and description for your pull request, explaining the changes and why they are needed.
+
+## Code of Conduct
+
+By participating in this project, you are expected to uphold our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Reporting Bugs
+
+If you find a bug, please open an issue in the repository, providing as much detail as possible.
+
+## Requesting Features
+
+If you have an idea for a new feature, please open an issue to discuss it.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,117 @@
-# tokman-cli
-A library intended to generate design tokens from a style source
+# Tokman CLI 🪙
+
+**A powerful CLI tool for generating and managing design tokens from your style source.**
+
+Tokman CLI helps streamline your design system workflow by automating the creation of design tokens, ensuring consistency across platforms and projects.
+
+## Features ✨
+
+*   **Feature 1:** Brief description of what it does.
+*   **Feature 2:** Brief description of what it does.
+*   **Feature 3:** Brief description of what it does.
+    *   Sub-feature A
+    *   Sub-feature B
+*   Easy integration with popular styling formats (e.g., JSON, YAML, CSS Variables, etc. - *Specify actual formats*).
+*   Extensible architecture for custom transformations and outputs.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Usage](#usage)
+  - [Commands](#commands)
+  - [Configuration](#configuration)
+- [Contributing](#contributing)
+- [Code of Conduct](#code-of-conduct)
+- [License](#license)
+
+## Installation 🚀
+
+```bash
+# Using npm (Node.js package manager)
+npm install -g tokman-cli
+
+# Using yarn
+yarn global add tokman-cli
+
+# For local project usage
+npm install --save-dev tokman-cli
+# or
+yarn add --dev tokman-cli
+```
+*(Adjust installation instructions based on the actual package manager and distribution method if different, e.g., direct download, other package managers.)*
+
+## Quick Start 🏁
+
+1.  **Initialize Configuration:**
+    ```bash
+    tokman init
+    ```
+    This will create a `tokman.config.js` (or similar) file in your project root.
+
+2.  **Define your style source(s)** in the configuration file.
+    Example `tokman.config.js`:
+    ```javascript
+    // tokman.config.js (example)
+    module.exports = {
+      source: ['./styles/tokens.json'], // Path to your token definitions
+      platforms: {
+        css: {
+          transformGroup: 'css',
+          buildPath: 'dist/css/',
+          files: [{
+            destination: 'variables.css',
+            format: 'css/variables'
+          }]
+        },
+        // Add other platforms like scss, js, android, ios etc.
+      }
+    };
+    ```
+    *(This is a common structure for token tools like Style Dictionary; adjust if Tokman's config is different).*
+
+3.  **Build your tokens:**
+    ```bash
+    tokman build
+    ```
+    Your generated tokens will be in the `dist/` directory (or as configured).
+
+## Usage 🛠️
+
+### Commands
+
+*   `tokman init`: Initialize a new configuration file.
+*   `tokman build`: Build/generate tokens based on the configuration.
+*   `tokman clean`: Remove previously built artifacts.
+*   `tokman --help`: Display help information for all commands.
+*   `tokman <command> --help`: Display help for a specific command.
+
+*(Add or modify commands as per actual CLI functionality)*
+
+### Configuration
+
+Tokman CLI is configured via a `tokman.config.js` (or `.json`, `.yaml`) file in your project root.
+
+Key configuration options:
+*   `source`: An array of glob patterns for your token source files.
+*   `platforms`: An object defining output platforms (e.g., CSS, JS, SCSS, Android, iOS). Each platform specifies transformations, build path, and output files.
+
+Refer to the [Full Configuration Documentation](docs/CONFIGURATION.md) for more details. *(Consider creating a more detailed configuration doc if needed)*
+
+## Contributing 🤝
+
+We welcome contributions from the community! Whether it's reporting a bug, suggesting a feature, or submitting a pull request, your help is appreciated.
+
+Please read our [Contributing Guidelines](CONTRIBUTING.md) to get started.
+
+## Code of Conduct 📜
+
+To ensure a welcoming and inclusive environment, we expect all contributors and participants to adhere to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License 📄
+
+This project is licensed under the [MIT License](LICENSE).
+
+---
+
+*Remember to update placeholders (like feature descriptions, installation steps if not an npm package, configuration details, command list) with actual information specific to `tokman-cli`.*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The project team takes security vulnerabilities seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security vulnerability, please email [INSERT EMAIL ADDRESS OR LINK TO SECURITY REPORTING FORM/PAGE] with a detailed description of the vulnerability, steps to reproduce it, and any potential impact.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+You should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
+
+## Our Commitment
+
+*   We will acknowledge receipt of your vulnerability report and provide an estimated timeline for addressing it.
+*   We will work with you to understand and validate the vulnerability.
+*   We will notify you when the vulnerability has been fixed and publicly disclose it, if appropriate, crediting you for the discovery unless you prefer to remain anonymous.
+
+## Scope
+
+This security policy applies to the latest version of the project.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "tokman-cli",
+  "version": "0.1.0",
+  "description": "A library intended to generate design tokens from a style source",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+  },
+  "keywords": [
+    "design-tokens",
+    "cli",
+    "tokens",
+    "style-management"
+  ],
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/USERNAME/REPOSITORY.git"
+  },
+  "bugs": {
+    "url": "https://github.com/USERNAME/REPOSITORY/issues"
+  },
+  "homepage": "https://github.com/USERNAME/REPOSITORY#readme",
+  "devDependencies": {
+    "eslint": "^8.0.0"
+  }
+}


### PR DESCRIPTION
This commit introduces a set of standard files and configurations to enhance the project's structure, maintainability, and community engagement, based on common practices and reference projects like packman-cli and stateman-cli.

Added:
- `.github/workflows/ci.yml`: A basic GitHub Actions CI workflow for Node.js projects (linting and testing placeholders included).
- `CODE_OF_CONDUCT.md`: Contributor Covenant Code of Conduct.
- `CONTRIBUTING.md`: Guidelines for contributing to the project.
- `SECURITY.md`: Policy for reporting security vulnerabilities.
- `CODEOWNERS.md`: Template for defining code ownership.
- `CITATION.md`: Template for citing the project.
- `.editorconfig`: Configuration for consistent editor settings.
- `package.json`: Basic Node.js project manifest with scripts and metadata (assuming Node.js project).
- `.eslintrc.json`: Basic ESLint configuration for JavaScript/TypeScript linting.

Refined:
- `README.md`: Expanded with a more comprehensive structure, including sections for features, installation, usage, and more. (Requires project-specific details to be filled in).

Reviewed:
- `LICENSE`: Existing MIT license confirmed to be appropriate.

These additions provide a foundational setup for development, collaboration, and automation. Project-specific details (e.g., in README, CODEOWNERS, CITATION, package.json) should be filled in by you.